### PR TITLE
add RelatedOccupation component with mock data

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,4 +1,5 @@
 import { postSearchQuery } from '../services/relatedOccupationsSearchService';
+import { RelatedOccupation } from './RelatedOccupation';
 
 export const Home = () => {
   const handleClick = async () => {
@@ -10,6 +11,7 @@ export const Home = () => {
   return (
     <>
       <button onClick={handleClick}>Send mockdata</button>
+      <RelatedOccupation />
     </>
   );
 };

--- a/src/components/RelatedOccupation.tsx
+++ b/src/components/RelatedOccupation.tsx
@@ -1,0 +1,38 @@
+import {
+  DigiButton,
+  DigiLayoutContainer,
+  DigiTypography,
+} from '@digi/arbetsformedlingen-react';
+// import { IRelatedOccupations } from '../models/IRelatedOccupations';
+import {
+  ButtonSize,
+  ButtonVariation,
+  TypographyVariation,
+} from '@digi/arbetsformedlingen';
+
+// interface IRelatedOccupationProps {
+//   occupation: IRelatedOccupations;
+// }
+
+export const RelatedOccupation = () => {
+  const handleClick = () => {
+    console.log('id');
+  };
+
+  return (
+    <DigiLayoutContainer afVerticalPadding>
+      <DigiTypography afVariation={TypographyVariation.SMALL}>
+        <h2>occupation_label</h2>
+        <p>Yrkesgrupp: occupation_group.occupation_group_label</p>
+        <DigiButton
+          afSize={ButtonSize.SMALL}
+          afVariation={ButtonVariation.PRIMARY}
+          afFullWidth={false}
+          onAfOnClick={handleClick}
+        >
+          Läs mer
+        </DigiButton>
+      </DigiTypography>
+    </DigiLayoutContainer>
+  );
+};


### PR DESCRIPTION
Created skeleton component for RelatedOccupation.
<img width="440" alt="Screenshot 2023-09-15 at 15 16 05" src="https://github.com/Medieinstitutet/case-f-r-arbetsf-rmedlingen-och-jobtech-grupp-10-1/assets/95872411/81436143-7d07-41e5-8d86-645be6289736">
<img width="587" alt="Screenshot 2023-09-15 at 15 16 22" src="https://github.com/Medieinstitutet/case-f-r-arbetsf-rmedlingen-och-jobtech-grupp-10-1/assets/95872411/791f242b-820e-4a2b-84a8-5c4bb0fda169">
